### PR TITLE
Force className to render as class

### DIFF
--- a/html.js
+++ b/html.js
@@ -30,6 +30,8 @@ var html = (function(documentToBind) {
         if(eTemp.hasOwnProperty(attr) && excludeList.indexOf(attr) < 0) {
           if (attr === 'text') {
             element.innerHTML = eTemp[attr]
+          } else if (attr === 'className') {
+            element.setAttribute('class', eTemp['className'])
           } else {
             element.setAttribute(attr, eTemp[attr])
           }


### PR DESCRIPTION
Currently, Readme indicates that passing `className` at a node will cause the rendered HTML to have the class attribute. I like this behavior since it's similar to React.

However, className is not currently being treated correctly:

```
html = require("html-chain")
html().add("div", { className: "hi" }).build()
```

This returns:

```
<div className="hi"></div>
```

I've updated `html.js` so this works correctly. This should be a mostly non-breaking change since passing `class` directly will still work as well.
